### PR TITLE
Cargo: Bump uefi-rs versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,8 +204,9 @@ dependencies = [
 
 [[package]]
 name = "uefi"
-version = "0.34.1"
-source = "git+https://github.com/rust-osdev/uefi-rs.git#c5d99aaf34fcb7aae50f8d84537fa7cb85cce3a5"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7569ceafb898907ff764629bac90ac24ba4203c38c33ef79ee88c74aa35b11"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -219,8 +220,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-macros"
-version = "0.18.0"
-source = "git+https://github.com/rust-osdev/uefi-rs.git#e3d5afb18425df85f4f335ccb37eac7f6fd83265"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3dad47b3af8f99116c0f6d4d669c439487d9aaf1c8d9480d686cda6f3a8aa23"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -229,8 +231,9 @@ dependencies = [
 
 [[package]]
 name = "uefi-raw"
-version = "0.10.0"
-source = "git+https://github.com/rust-osdev/uefi-rs.git#e3d5afb18425df85f4f335ccb37eac7f6fd83265"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cad96b8baaf1615d3fdd0f03d04a0b487d857c1b51b19dcbfe05e2e3c447b78"
 dependencies = [
  "bitflags",
  "uguid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,6 @@ publish = false
 [dependencies]
 ffi = "0.1.1"
 log = "0.4"
-uefi = { version = "0.34.1", features = ["alloc", "global_allocator", "logger", "panic_handler"] }
-uefi-raw = "0.10.0"
+uefi = { version = "0.35", features = ["alloc", "global_allocator", "logger", "panic_handler"] }
+uefi-raw = "0.11.0"
 uguid = "2.2.0"
-
-[patch.crates-io]
-uefi = { git = "https://github.com/rust-osdev/uefi-rs.git" }
-uefi-macros = { git = "https://github.com/rust-osdev/uefi-rs.git" }
-uefi-raw = { git = "https://github.com/rust-osdev/uefi-rs.git" }


### PR DESCRIPTION
uefi and uefi-raw crates has been released with the API additions we depend on, so bump to a released version.