### PR TITLE
main: provide default serial number

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -267,7 +267,8 @@ fn generate_serial_number() -> Result<CString16> {
 fn main() -> Status {
     uefi::helpers::init().unwrap();
 
-    let serial_number = generate_serial_number().unwrap();
+    let serial_number =
+        generate_serial_number().unwrap_or(CString16::try_from("deadcafe").unwrap());
 
     signal_usb_controller_init().expect("failed to signal usb controller initialization");
 


### PR DESCRIPTION
Provide a default serial number instead of panicing if the UEFI doesn't implement CardInfo protocol.