### PR TITLE
repart: Fix the EFI binary name

### DIFF
--- a/repart.d/efi.conf
+++ b/repart.d/efi.conf
@@ -1,4 +1,4 @@
 [Partition]
 Format=vfat
 Type=esp
-CopyFiles=/target/aarch64-unknown-uefi/debug/fastboot-rs.efi:/EFI/boot/bootaa64.efi
+CopyFiles=/target/aarch64-unknown-uefi/debug/fastboot.efi:/EFI/boot/bootaa64.efi


### PR DESCRIPTION
Cargo build no longer generates 'fastboot-rs.efi'. Hence, fix the binary name to build the ESP partition image.