### PR TITLE
abootimg: Gracefully handle boot images without DTB

### DIFF
--- a/src/abootimg.rs
+++ b/src/abootimg.rs
@@ -244,10 +244,16 @@ pub(crate) fn handle_bootimg_v2(
         .write(&payload[ramdisk_offset..ramdisk_offset + ramdisk_size])
         .with_context("failed to write ramdisk payload")?;
 
-    let mut dtb = FastbootBuffer::alloc(MemoryType::ACPI_RECLAIM, dtb_size)
-        .with_context("failed to allocate memory for fdt")?;
-    dtb.write(&payload[dtb_offset..dtb_offset + dtb_size])
-        .with_context("failed to write fdt")?;
+    if dtb_size != 0 {
+        let mut dtb = FastbootBuffer::alloc(MemoryType::ACPI_RECLAIM, dtb_size)
+            .with_context("failed to allocate memory for fdt")?;
+        dtb.write(&payload[dtb_offset..dtb_offset + dtb_size])
+            .with_context("failed to write fdt")?;
+        dtb.install_configuration_table(&EFI_FDT_TABLE)
+            .with_context("failed to install fdt in configuration table")?;
+    } else {
+        info!("NOTICE: Image does not contain a DeviceTree");
+    }
 
     let cmdline_len = aboot2
         .cmdline
@@ -268,8 +274,6 @@ pub(crate) fn handle_bootimg_v2(
 
     let handle = kernel.load_image().expect("failed to load the kernel");
 
-    dtb.install_configuration_table(&EFI_FDT_TABLE)
-        .with_context("failed to install fdt in configuration table")?;
     let mut loaded_image = boot::open_protocol_exclusive::<LoadedImage>(handle)
         .with_context("failed to load image")?;
     unsafe {


### PR DESCRIPTION
The --dtb option to mkbootimg is an optional argument, and sometimes you do want to "fastboot boot" an image without overriding the present tables, so make the installation into configuration table optional as well.