### PR TITLE
abootimg: Fix gzip decompressed kernel size passed to load_image()

### DIFF
--- a/src/abootimg.rs
+++ b/src/abootimg.rs
@@ -118,14 +118,14 @@ fn gzip_deflate_slice(data: &[u8]) -> Option<&[u8]> {
     Some(&data[offset..data.len() - 8])
 }
 
-fn gzip_decompress(payload: &[u8], output: &mut [u8]) -> Result<(), &'static str> {
+fn gzip_decompress(payload: &[u8], output: &mut [u8]) -> Result<usize, &'static str> {
     let deflate_data = gzip_deflate_slice(payload).unwrap();
     let mut decomp = DecompressorOxide::new();
 
-    let (status, _, _) = decompress(&mut decomp, deflate_data, output, 0, 0);
+    let (status, _, out_consumed) = decompress(&mut decomp, deflate_data, output, 0, 0);
 
     match status {
-        TINFLStatus::Done => Ok(()),
+        TINFLStatus::Done => Ok(out_consumed),
         _ => Err(Error::new(
             Status::LOAD_ERROR,
             "failed to decompress kernel",
@@ -216,10 +216,11 @@ pub(crate) fn handle_bootimg_v2(
             FastbootBuffer::alloc(MemoryType::RUNTIME_SERVICES_CODE, 128 * 1024 * 1024)
                 .with_context("failed to allocate memory for kernel")?;
 
-        gzip_decompress(
+        let decompressed_size = gzip_decompress(
             &payload[kernel_offset..kernel_offset + kernel_size],
             kernel.as_mut_slice(),
         )?;
+        kernel.len = decompressed_size;
 
         kernel
     } else {


### PR DESCRIPTION
gzip_decompress() was discarding the out_consumed return value from miniz_oxide's decompress(), leaving FastbootBuffer::len set to the full 128 MiB allocation. load_image() then passed that oversized buffer to UEFI's LoadImage, causing it to fail with LOAD_ERROR since the trailing zeroes don't constitute a valid PE image.

Fix by returning out_consumed from gzip_decompress() and updating kernel.len to the actual decompressed size before calling load_image().

It fixes the failure below seen on qcs9100-ride when booting Image.gz built into abootimg.

  Dev_Common_Speed: Dev Bus Speed: Super, state 2
  Allocated E18000 bytes
  Response: DATA00E18000 (12)
  Response: OKAY (4)
  kernel: 0xBA5780@0x1000
  ramdisk: 0x240224@0xBA7000
  dtb: 0x2FBDC@0xDE8000
  ERROR: Encountered NULL ImageContext
  Error: Failed to load kernel image

Fixes: 87a73888777f ("abootimg: Implement decompress")