### PR TITLE
README: Clean up the rawprogram artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,15 @@ or:
 systemd-repart fastboot-ufs-disk.img --empty=create --size=512M --sector-size=4096 --definitions=repart.d --root=$PWD
 ```
 
-This file can be written straight to a NVMe (or UFS) device, which upon booting
-automatically enters fastboot mode.
+These files can be written straight to a NVMe or UFS device, starting at sector
+0, using e.g. **qdl**, e.g.:
 
-*rawprogram-nvme.xml* and *rawprogram-ufs.xml* are included for convenient
-application with common flash tools.
+
+```
+qdl prog_firehose_ddr.elf --storage ufs write 0 fastboot-ufs-disk.img
+```
+
+Upon booting the device will automatically enter fastboot mode.
 
 ## *fastboot boot* an UKI (or other EFI application)
 

--- a/rawprogram-nvme.xml
+++ b/rawprogram-nvme.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" ?>
-<data>
-	<program SECTOR_SIZE_IN_BYTES="512" file_sector_offset="0" filename="fastboot-nvme-disk.img" label="fastboot" num_partition_sectors="0" partofsingleimage="false" physical_partition_number="0" readbackverify="false" size_in_KB="0" sparse="false" start_byte_hex="0x0" start_sector="0"/>
-</data>

--- a/rawprogram-ufs.xml
+++ b/rawprogram-ufs.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" ?>
-<data>
-	<program SECTOR_SIZE_IN_BYTES="4096" file_sector_offset="0" filename="fastboot-ufs-disk.img" label="fastboot" num_partition_sectors="0" partofsingleimage="false" physical_partition_number="0" readbackverify="false" size_in_KB="0" sparse="false" start_byte_hex="0x0" start_sector="0"/>
-</data>


### PR DESCRIPTION
QDL has for a while been able to write binaries directly to the storage device, without the need for rawprogram xml files. Drop the xml files and update the README.